### PR TITLE
Initialize contribution guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,7 +45,8 @@ If you have implemented a bug fix or developed a new feature yourself, you can s
 1. Fork the [Fredhopper/SAP Hybris Connector repository](https://github.com/fredhopper/hybris-connector) to your account.
 1. Implement your code changes in the fork. 
 1. Make sure to test your work extensively.
+1. Rebase your changes on the latest `master` of the main repository.
 1. Submit a pull request from your fork to the `master` branch of the main repository.<br>Make sure that all commit messages and the pull request body are as descriptive as possible.
 1. Fix any comments from reviews.
 
-After the Fredhopper team has approved the suggested changes, they will **squash and merge** the pull request.
+After we have approved the suggested changes, we will **squash and merge** the pull request. Note, that we might request that you rebase and fix any conflicts that might prevent us from merging the pull request.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contribute to the Fredhopper/SAP Hybris Connector
+
+*Help improve the Fredhopper/SAP Hybris Connector*
+
+![](Fredhopper_logo.jpg)
+
+With the *Fredhopper/SAP Hybris Connector*, you can leverage the advanced on-site search, navigation, personalisation, and merchandising capabilities of Fredhopper in your hybris-based online marketplace.
+
+* [Reporting an Issue](#reporting-an-issue)
+* [Requesting a Feature](#requesting-a-feature)
+* [Contributing to the Code](#contributing-to-the-code)
+
+## Reporting an Issue
+
+To report bugs in the source code, you can submit an issue, labeled as *bug*, to the [Fredhopper/SAP Hybris Connector repository](https://github.com/fredhopper/hybris-connector/issues).
+
+1. Before you submit the issue, make sure that you have checked for similar reports in the archive. 
+1. Use the title and the body of the issue to provide us with the following information: 
+    * a clear **problem statement**
+    * detailed **steps to reproduce** with **expected behavior** and **actual behavior**
+    * information about your **system configuration**
+    * any **related issues**
+    * if available, a **suggested fix**
+1. Label the issue as *bug*.
+
+If you want to implement the bug fix yourself, consider submitting it as a pull request (see [Contributing to the Code](#contributing-to-the-code)).
+
+## Requesting a Feature
+
+For any improvements or suggestions that you'd like to see implemented in the *Fredhopper/SAP Hybris Connector*, you can submit an issue, labeled as *enhancement*, to the [Fredhopper/SAP Hybris Connector repository](https://github.com/fredhopper/hybris-connector/issues).
+
+1. Before you submit a feature request, make sure that you have checked for similar requests in the archive. 
+1. Use the title and the body of the feature request to provide us with the following information: 
+    * a clear **feature overview**
+    * detailed **business case**, or how this feature will improve your work 
+1. Label the issue as *enhancement*. 
+
+If you want to implement the new feature yourself, consider submitting it as a pull request (see [Contributing to the Code](#contributing-to-the-code)).
+
+## Contributing to the Code
+
+If you have implemented a bug fix or developed a new feature yourself, you can submit a pull request to the [Fredhopper/SAP Hybris Connector repository](https://github.com/fredhopper/hybris-connector/pulls).
+
+1. Before you begin working, make sure that you have checked for similar open or closed pull requests in the archive.
+1. Fork the [Fredhopper/SAP Hybris Connector repository](https://github.com/fredhopper/hybris-connector) to your account.
+1. Implement your code changes in the fork. 
+1. Make sure to test your work extensively.
+1. Submit a pull request from your fork to the `master branch` of the main repository.<br>Make sure that all commit messages and the pull request body are as descriptive as possible.
+1. Fix any comments from reviews.
+
+After the Fredhopper team has approved the suggested changes, they will **squash and merge** the pull request.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribute to the Fredhopper/SAP Hybris Connector
 
-*Help improve the Fredhopper/SAP Hybris Connector*
+*Help us improve the Fredhopper/SAP Hybris Connector*
 
 ![](../Fredhopper_logo.jpg)
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,7 +45,7 @@ If you have implemented a bug fix or developed a new feature yourself, you can s
 1. Fork the [Fredhopper/SAP Hybris Connector repository](https://github.com/fredhopper/hybris-connector) to your account.
 1. Implement your code changes in the fork. 
 1. Make sure to test your work extensively.
-1. Submit a pull request from your fork to the `master branch` of the main repository.<br>Make sure that all commit messages and the pull request body are as descriptive as possible.
+1. Submit a pull request from your fork to the `master` branch of the main repository.<br>Make sure that all commit messages and the pull request body are as descriptive as possible.
 1. Fix any comments from reviews.
 
 After the Fredhopper team has approved the suggested changes, they will **squash and merge** the pull request.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 *Help improve the Fredhopper/SAP Hybris Connector*
 
-![](Fredhopper_logo.jpg)
+![](./Fredhopper_logo.jpg)
 
 With the *Fredhopper/SAP Hybris Connector*, you can leverage the advanced on-site search, navigation, personalisation, and merchandising capabilities of Fredhopper in your hybris-based online marketplace.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 *Help improve the Fredhopper/SAP Hybris Connector*
 
-![](./Fredhopper_logo.jpg)
+![](../Fredhopper_logo.jpg)
 
 With the *Fredhopper/SAP Hybris Connector*, you can leverage the advanced on-site search, navigation, personalisation, and merchandising capabilities of Fredhopper in your hybris-based online marketplace.
 


### PR DESCRIPTION
This is a very generic contribution guide. I recommend creating an additional document with information for developers, such as dev environment setup, coding guidelines, etc. (I'll open an issue for that.)

I've placed the document in the hidden .github folder where we can also place an issue template and a pull request template. Let me know if you'd like me to move the document in the root.